### PR TITLE
Update TeXworks download & munki recipes

### DIFF
--- a/TeXworks/TeXworks.download.recipe
+++ b/TeXworks/TeXworks.download.recipe
@@ -8,8 +8,8 @@
 	<string>com.github.joncrain.download.TeXworks</string>
 	<key>Input</key>
 	<dict>
-		<key>GITHUB_REPO</key>
-		<string>TeXworks/TeXworks</string>
+		<key>ASSET_REGEX</key>
+		<string>^.*.dmg$</string>
 		<key>NAME</key>
 		<string>TeXworks</string>
 	</dict>
@@ -20,8 +20,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>asset_regex</key>
+				<string>%ASSET_REGEX%</string>
 				<key>github_repo</key>
-				<string>%GITHUB_REPO%</string>
+				<string>TeXworks/TeXworks</string>
 			</dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>

--- a/TeXworks/TeXworks.munki.recipe
+++ b/TeXworks/TeXworks.munki.recipe
@@ -48,6 +48,27 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>version</key>
+				<string>%version%</string>
+			</dict>
+			<key>Processor</key>
+			<string>com.github.homebysix.VersionSplitter/VersionSplitter</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>version</key>
+					<string>%version%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>pkg_path</key>
 				<string>%pathname%</string>
 				<key>repo_subdirectory</key>


### PR DESCRIPTION
Accomplishes the following:
- Ensures we get the right Github asset, since there's more than 1
- Removes the extraneous app version data after the space to get a nicer version:
  - `0.6.5 (r.649699a)` becomes `0.6.5`

Successful verbose recipe output given changes:

```
autopkg run ~/Documents/GitHub/joncrain-recipes/TeXworks/TeXworks.munki.recipe -vv
Processing /Users/admin/Documents/GitHub/joncrain-recipes/TeXworks/TeXworks.munki.recipe...
WARNING: /Users/admin/Documents/GitHub/joncrain-recipes/TeXworks/TeXworks.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': u'^.*.dmg$', 'github_repo': u'TeXworks/TeXworks'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '^.*.dmg$' among asset(s): TeXworks-osx-0.6.5-202003251937-git_649699a.dmg, TeXworks-win-0.6.5-202003252107-git_649699a.zip, TeXworks-win-setup-0.6.5-202003252107-git_649699a.exe
GitHubReleasesInfoProvider: Selected asset 'TeXworks-osx-0.6.5-202003251937-git_649699a.dmg' from release 'TeXworks 0.6.5'
{'Output': {'release_notes': u'Bug fixes:\r\n * Fix text selection handling when moving the mouse\r\n * Fix auto-reloading of TeX documents that were changed outside TeXworks\r\n\r\nMisc:\r\n * Update translations\r\n\r\nLibraries for pre-built binaries:\r\n * Mac OS X: Qt 5.14.1, Hunspell 1.7.0, Poppler 0.85.0, poppler-data 0.4.7, Lua 5.3.5\r\n * Windows: Qt 5.14.1, Hunspell 1.7.0, Poppler 0.85.0, poppler-data 0.4.9, Lua 5.3.3\r\n',
            'url': u'https://github.com/TeXworks/texworks/releases/download/release-0.6.5/TeXworks-osx-0.6.5-202003251937-git_649699a.dmg',
            'version': u'release-0.6.5'}}
URLDownloader
{'Input': {'CURL_PATH': '/usr/bin/curl',
           'filename': u'TeXworks-release-0.6.5.dmg',
           'url': u'https://github.com/TeXworks/texworks/releases/download/release-0.6.5/TeXworks-osx-0.6.5-202003251937-git_649699a.dmg'}}
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/admin/Library/AutoPkg/Cache/com.github.joncrain.munki.TeXworks/downloads/TeXworks-release-0.6.5.dmg
{'Output': {'pathname': u'/Users/admin/Library/AutoPkg/Cache/com.github.joncrain.munki.TeXworks/downloads/TeXworks-release-0.6.5.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
AppDmgVersioner
{'Input': {'dmg_path': u'/Users/admin/Library/AutoPkg/Cache/com.github.joncrain.munki.TeXworks/downloads/TeXworks-release-0.6.5.dmg'}}
AppDmgVersioner: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.joncrain.munki.TeXworks/downloads/TeXworks-release-0.6.5.dmg
AppDmgVersioner: BundleID: org.tug.texworks
AppDmgVersioner: Version: 0.6.5 (r.649699a)
{'Output': {'app_name': u'TeXworks.app',
            'bundleid': u'org.tug.texworks',
            'version': u'0.6.5 (r.649699a)'}}
com.github.homebysix.VersionSplitter/VersionSplitter
{'Input': {'version': u'0.6.5 (r.649699a)'}}
VersionSplitter: Split version: 0.6.5
{'Output': {'version': u'0.6.5'}}
MunkiPkginfoMerger
{'Input': {'additional_pkginfo': {
    version = "0.6.5";
},
           'pkginfo': {
    catalogs =     (
        testing
    );
    description = "TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.";
    developer = TUG;
    "display_name" = TeXworks;
    name = TeXworks;
    "unattended_install" = 1;
}}}
MunkiPkginfoMerger: Merged {
    version = "0.6.5";
} into pkginfo
{'Output': {'pkginfo': {
    catalogs =     (
        testing
    );
    description = "TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.";
    developer = TUG;
    "display_name" = TeXworks;
    name = TeXworks;
    "unattended_install" = 1;
    version = "0.6.5";
}}}
MunkiImporter
{'Input': {'MUNKI_REPO': u'/Users/Shared',
           'pkg_path': u'/Users/admin/Library/AutoPkg/Cache/com.github.joncrain.munki.TeXworks/downloads/TeXworks-release-0.6.5.dmg',
           'pkginfo': {
    catalogs =     (
        testing
    );
    description = "TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.";
    developer = TUG;
    "display_name" = TeXworks;
    name = TeXworks;
    "unattended_install" = 1;
    version = "0.6.5";
},
           'repo_subdirectory': u'apps/TeXworks'}}
MunkiImporter: Copied pkginfo to /Users/Shared/pkgsinfo/apps/TeXworks/TeXworks-0.6.5.plist
MunkiImporter: Copied pkg to /Users/Shared/pkgs/apps/TeXworks/TeXworks-release-0.6.5.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': u'testing',
                                                       'name': u'TeXworks',
                                                       'pkg_repo_path': u'apps/TeXworks/TeXworks-release-0.6.5.dmg',
                                                       'pkginfo_path': u'apps/TeXworks/TeXworks-0.6.5.plist',
                                                       'version': u'0.6.5'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path'],
                                              'summary_text': 'The following new items were imported into Munki:'},
            'munki_info': {
    "_metadata" =     {
        "created_by" = "admin";
        "creation_date" = "2020-06-01 17:14:08 +0000";
        "munki_version" = "3.6.2.3776";
        "os_version" = "10.14.6";
    };
    autoremove = 0;
    catalogs =     (
        testing
    );
    description = "TeXworks is an environment for authoring TeX (LaTeX, ConTeXt, etc) documents, with a Unicode-based, TeX-aware editor, integrated PDF viewer, and a clean, simple interface accessible to casual and non-technical users.";
    developer = TUG;
    "display_name" = TeXworks;
    "installer_item_hash" = c171ad80782485f0bdd15a611fc234a94d38144fb2ee183ec50377338df5d690;
    "installer_item_location" = "apps/TeXworks/TeXworks-release-0.6.5.dmg";
    "installer_item_size" = 22821;
    "installer_type" = "copy_from_dmg";
    installs =     (
                {
            CFBundleIdentifier = "org.tug.texworks";
            CFBundleShortVersionString = "0.6.5 (r.649699a)";
            CFBundleVersion = "0.6.5 (r.649699a)";
            path = "/Applications/TeXworks.app";
            type = application;
            "version_comparison_key" = CFBundleShortVersionString;
        }
    );
    "items_to_copy" =     (
                {
            "destination_path" = "/Applications";
            "source_item" = "TeXworks.app";
        }
    );
    "minimum_os_version" = "10.4.0";
    name = TeXworks;
    "unattended_install" = 1;
    "uninstall_method" = "remove_copied_items";
    uninstallable = 1;
    version = "0.6.5";
},
            'munki_repo_changed': True,
            'pkg_repo_path': u'/Users/Shared/pkgs/apps/TeXworks/TeXworks-release-0.6.5.dmg',
            'pkginfo_repo_path': u'/Users/Shared/pkgsinfo/apps/TeXworks/TeXworks-0.6.5.plist'}}
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.joncrain.munki.TeXworks/receipts/TeXworks.munki-receipt-20200601-131408.plist

The following new items were imported into Munki:
    Name      Version  Catalogs  Pkginfo Path                        Pkg Repo Path                             
    ----      -------  --------  ------------                        -------------                             
    TeXworks  0.6.5    testing   apps/TeXworks/TeXworks-0.6.5.plist  apps/TeXworks/TeXworks-release-0.6.5.dmg
```