### PR TITLE
PlasticSCM update for new pkg name

### DIFF
--- a/PlasticSCM/PlasticSCM-cloud.download.recipe
+++ b/PlasticSCM/PlasticSCM-cloud.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe will soon be moved to Unity VCS.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
@@ -66,7 +75,7 @@
 					<string>Apple Root CA</string>
 				</array>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/plasticscm-cloud-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/unity-vcs-%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -77,7 +86,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/plasticscm-cloud-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/unity-vcs-%version%.pkg</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>

--- a/PlasticSCM/PlasticSCM-cloud.munki.recipe
+++ b/PlasticSCM/PlasticSCM-cloud.munki.recipe
@@ -24,9 +24,9 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>Plastic SCM is a commercial SCM system developed by Codice Software. Plastic tries to focus on big repositories, parallel development, branching and merging and security.</string>
+			<string>Plastic SCM is now Unity Version Control, a component of Unity DevOps. Unity Version Control is a scalable, engine-agnostic version control and source code management tool for game development studios of all sizes.</string>
 			<key>developer</key>
-			<string>Codice Software</string>
+			<string>Unity Technologies</string>
 			<key>display_name</key>
 			<string>PlasticSCM - Cloud Edition</string>
 			<key>name</key>

--- a/PlasticSCM/PlasticSCM-enterprise.download.recipe
+++ b/PlasticSCM/PlasticSCM-enterprise.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe will soon be moved to Unity VCS.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
@@ -66,7 +75,7 @@
 					<string>Apple Root CA</string>
 				</array>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/plasticscm-full-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/unity-vcs-on-prem-full-%version%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -77,7 +86,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/plasticscm-full-%version%.pkg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/unity-vcs-on-prem-full-%version%.pkg</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>

--- a/PlasticSCM/PlasticSCM-enterprise.munki.recipe
+++ b/PlasticSCM/PlasticSCM-enterprise.munki.recipe
@@ -24,9 +24,9 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>Plastic SCM is a commercial SCM system developed by Codice Software. Plastic tries to focus on big repositories, parallel development, branching and merging and security.</string>
+			<string>Plastic SCM is now Unity Version Control, a component of Unity DevOps. Unity Version Control is a scalable, engine-agnostic version control and source code management tool for game development studios of all sizes.</string>
 			<key>developer</key>
-			<string>Codice Software</string>
+			<string>Unity Technologies</string>
 			<key>display_name</key>
 			<string>PlasticSCM - Enterprise Edition</string>
 			<key>name</key>


### PR DESCRIPTION
PlasticSCM is now Unity VCS. 
The name of the downloaded pkg has changed. The download location and zip file may also change in the future. Adding a deprecation notice for this recipe. The Unity VCS recipes have not been created yet, but will be soon.